### PR TITLE
Release 1.7

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 El Oyente
 =========
 
-This project delivers a Jenkins plugin which adds job triggering based on
-XMPP events.  See http://xmpp.org/extensions/xep-0060.html for more details
-about the PubSub extension of XMPP.
+This project delivers a Jenkins plugin which adds job triggering based on XMPP events.
+Since version 1.4 it also includes the publisher to send xmpp pubsub events, as a buildstep.
+See http://xmpp.org/extensions/xep-0060.html for more details about the PubSub extension of XMPP.

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     </parent>
     <groupId>com.technicolor</groupId>
     <artifactId>elOyente</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.4</version>
     <packaging>hpi</packaging>
     <scm>
         <connection>scm:git:ssh://github.com/dnnsjcbs/eloyente.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     </parent>
     <groupId>com.technicolor</groupId>
     <artifactId>elOyente</artifactId>
-    <version>1.7</version>
+    <version>1.8-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <scm>
         <connection>scm:git:ssh://github.com/dnnsjcbs/eloyente.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>1.499</version>
+        <relativePath></relativePath>
         <!-- which version of Jenkins is this plugin built against? -->
     </parent>
     <groupId>com.technicolor</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     </parent>
     <groupId>com.technicolor</groupId>
     <artifactId>elOyente</artifactId>
-    <version>1.6</version>
+    <version>1.7-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <scm>
         <connection>scm:git:ssh://github.com/dnnsjcbs/eloyente.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     </parent>
     <groupId>com.technicolor</groupId>
     <artifactId>elOyente</artifactId>
-    <version>1.4</version>
+    <version>1.5-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <scm>
         <connection>scm:git:ssh://github.com/dnnsjcbs/eloyente.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     </parent>
     <groupId>com.technicolor</groupId>
     <artifactId>elOyente</artifactId>
-    <version>1.6-SNAPSHOT</version>
+    <version>1.6</version>
     <packaging>hpi</packaging>
     <scm>
         <connection>scm:git:ssh://github.com/dnnsjcbs/eloyente.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
             <name>Frank Vanderhallen</name>
             <email>frank.vanderhallen@gmail.com</email>
         </developer>
+        <developer>
+            <id>dnnsjcbs</id>
+            <name>Dennis Jacobs</name>
+            <email>dennis.jacobs@technicolor.com</email>
+        </developer>
     </developers>
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -52,9 +57,9 @@
     <version>1.4-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <scm>
-        <connection>scm:git:ssh://github.com/jenkinsci/eloyente-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/eloyente-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/eloyente-plugin</url>
+        <connection>scm:git:ssh://github.com/dnnsjcbs/eloyente.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/dnnsjcbs/eloyente.git</developerConnection>
+        <url>https://github.com/dnnsjcbs/eloyente</url>
     </scm>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/El+Oyente+Plugin</url>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     </parent>
     <groupId>com.technicolor</groupId>
     <artifactId>elOyente</artifactId>
-    <version>1.5</version>
+    <version>1.6-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <scm>
         <connection>scm:git:ssh://github.com/dnnsjcbs/eloyente.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     </parent>
     <groupId>com.technicolor</groupId>
     <artifactId>elOyente</artifactId>
-    <version>1.7-SNAPSHOT</version>
+    <version>1.7</version>
     <packaging>hpi</packaging>
     <scm>
         <connection>scm:git:ssh://github.com/dnnsjcbs/eloyente.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -50,12 +50,12 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>1.499</version>
-        <relativePath></relativePath>
+        <relativePath />
         <!-- which version of Jenkins is this plugin built against? -->
     </parent>
     <groupId>com.technicolor</groupId>
     <artifactId>elOyente</artifactId>
-    <version>1.5-SNAPSHOT</version>
+    <version>1.5</version>
     <packaging>hpi</packaging>
     <scm>
         <connection>scm:git:ssh://github.com/dnnsjcbs/eloyente.git</connection>

--- a/src/main/java/com/technicolor/elboca/ElBoca.java
+++ b/src/main/java/com/technicolor/elboca/ElBoca.java
@@ -225,6 +225,7 @@ public class ElBoca extends Builder {
 	 * @param listener The logger for the jenkins console output.
 	 * @param element The element name.
 	 * @param xml_payload The payload in xml structure but in string format.
+	 * @param vars The variables which needs to be translated for the build.
 	 * @throws XMMPExceptioni when creatin a new stanza failed.
 	 * @throws SAXException upon a parsing error in the xml_payload.
 	 * @throws IOException IO error when parsing the xml_payload.
@@ -239,12 +240,15 @@ public class ElBoca extends Builder {
 		Collection<String> values = vars.values();
 		int var_count = vars.size();
 		String tmp = xml_payload;
-		i = 0;
 		for (String key :keys){ 
-			tmp = tmp.replaceAll(key, (String)values.toArray()[i]);
+			String tmp_key = "\\$\\{".concat(key).concat("\\}");
+                        if ( tmp.contains(tmp_key) == false ){
+				tmp = tmp.replaceAll(tmp_key, (String)values.toArray()[i]);
+			}
 			i++;
 		}
                 int start, end;
+		i = 0;
 		// find the root xml-tag
 		while (tmp.charAt(i) != '<'){
 			i++;

--- a/src/main/java/com/technicolor/eloyente/ElOyente.java
+++ b/src/main/java/com/technicolor/eloyente/ElOyente.java
@@ -759,7 +759,7 @@ public class ElOyente extends Trigger<Project> {
                 con.login(user, password);
                 if (con.isAuthenticated()) {
                     con.disconnect();
-                    return FormValidation.okWithMarkup("Authentication succed");
+                    return FormValidation.okWithMarkup("Authentication succeeded");
                 }
                 return FormValidation.warningWithMarkup("Not authenticated");
             } catch (XMPPException ex) {

--- a/src/main/resources/com/technicolor/elboca/ElBoca/config.jelly
+++ b/src/main/resources/com/technicolor/elboca/ElBoca/config.jelly
@@ -1,19 +1,20 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <!--
-   Copyright 2014 Technicolor
+ Copyright (c) 2014 Technicolor Delivery Technologies SAS
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+ http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 -->
+
 <f:entry title="Publish Event" var="properties">
     <f:entry title="${%node}" field="node">
       <f:textbox />

--- a/src/main/resources/com/technicolor/elboca/ElBoca/global.jelly
+++ b/src/main/resources/com/technicolor/elboca/ElBoca/global.jelly
@@ -1,19 +1,20 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <!--
-   Copyright 2014 Technicolor
+ Copyright (c) 2014 Technicolor Delivery Technologies SAS
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+ http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 -->
+
     <f:section title="XMPP PubSub Event Sending">
         <f:entry title="${%server}" field="server">
             <f:textbox />

--- a/src/main/resources/com/technicolor/elboca/ElBoca/help.html
+++ b/src/main/resources/com/technicolor/elboca/ElBoca/help.html
@@ -25,8 +25,8 @@
 	</p>
 	<p>
 		This plugin integrates XMPP Pub/Sub into Jenkins, which allows jobs started on different
-		jenkins servers. This is done through the ElOyente plugin, which picks up the sended
-		event, and starts the actual build.
+		jenkins servers. This is done through the ElOyente plugin, which picks up the sent
+		events, and starts the actual builds.
 	</p>
 </div>
 

--- a/src/main/resources/com/technicolor/elboca/index.jelly
+++ b/src/main/resources/com/technicolor/elboca/index.jelly
@@ -1,6 +1,0 @@
-<!--
-  This view is used to render the installed plugins page.
--->
-<div>
-  Xmpp PubSub plugin
-</div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -17,5 +17,4 @@
 <div>
   This plugin allows jobs to be triggered by XMPP Pub/Sub events.
   And to publish these events.
-  This plugin publishes xmpp PubSub events to an xmpp-server.
 </div>


### PR DESCRIPTION
Enabled parameterized builds in the xmpp payload, which need to be surrounded with '${' and '}'.
Fixed some typo's.
